### PR TITLE
Reference packes-dir and use testpypi as env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
     defaults:
       run:
         working-directory: ./deploy/pypi
-    environment: pypi
+    environment: testpypi
     permissions:
       contents: read
       # IMPORTANT: this permission is mandatory for Trusted Publishing
@@ -67,5 +67,6 @@ jobs:
       - name: Publish package distributions
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          packages-dir: deploy/pypi/dist
           # TODO, remove this part!
           repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
TO push to test pypi we need a slightly different environment and a failed action suggets that the gh-action-pypi-publish requires an absolute path to the pypi deployment dist.