### PR TITLE
Minor teaks to pypi publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,4 +79,4 @@ jobs:
         with:
           packages-dir: deploy/pypi/dist
           # TODO, remove this part!
-          repository-url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/simple/


### PR DESCRIPTION
Splits the build and deploy steps (as to prevent any vectors for the token).

Target the `simple/` instead of the `legacy/` end-point. Hopefully that fixes it. Currently getting a non-informative `400`.