### PR TITLE
Reintroduce pacakge-dir to gh-action-pypi-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -84,9 +83,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: python-dist
-          path: dist
+          path: deploy/pypi/dist
       - name: Publish package distributions
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          packages-dir: deploy/pypi/dist
           # TODO, remove this part!
           repository-url: https://test.pypi.org/simple/


### PR DESCRIPTION
Somehow... there is still repo content... despite no checkout was done.