### PR TITLE
Remove debug and use /legacy/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,9 +82,8 @@ jobs:
         with:
           name: python-dist
           path: dist
-      - run: ls -alh dist
       - name: Publish package distributions
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           # TODO, remove this part!
-          repository-url: https://test.pypi.org/simple/
+          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Success! Well, at least partially. Pypi is giving informative feedback about the endpoint.