### PR TITLE
Target production Pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
     # IMPORTANT: use a seperate job for this as each step has access to the tokens
     needs: build-for-pypi
     runs-on: ubuntu-latest
-    environment: testpypi
+    environment: pypi
     permissions:
       # IMPORTANT: this permission is mandatory for Trusted Publishing
       id-token: write
@@ -84,7 +84,3 @@ jobs:
           path: dist
       - name: Publish package distributions
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          verbose: true
-          # TODO, remove this part!
-          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Have the release workflow target production Pypi instead of the TestPypi.